### PR TITLE
Update for Elm 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,7 +14,7 @@
         "Constraint.Semigroup"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.1 <= v < 5.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/Accounting.elm
+++ b/examples/Accounting.elm
@@ -3,7 +3,7 @@ module Examples.Accounting exposing (..)
 import Constraint exposing (..)
 
 hole : a
-hole = hole
+hole = Debug.crash "hole"
 
 type HOLE = HOLE
 
@@ -38,20 +38,20 @@ type alias Environment env value = Constraint env (List value)
 (>=>) (Constraint f) (Constraint g) =
   ask <&> (\a -> List.concatMap g (f a))
 
-clientOrders' : Environment ClientOrderSheet Order
-clientOrders' =
+clientOrders_ : Environment ClientOrderSheet Order
+clientOrders_ =
   hole
 
-execute' : (Market, Account) -> Environment Order Execution
-execute' =
+execute_ : (Market, Account) -> Environment Order Execution
+execute_ =
   hole
 
-allocate' : List Account -> Environment Execution Trade
-allocate' =
+allocate_ : List Account -> Environment Execution Trade
+allocate_ =
   hole
 
-tradeGeneration' : (Market, Account, List Account) -> Environment ClientOrderSheet Trade
-tradeGeneration' (market, broker, clientAccounts) =
-  clientOrders'
-    >=> execute' (market, broker)
-    >=> allocate' clientAccounts
+tradeGeneration_ : (Market, Account, List Account) -> Environment ClientOrderSheet Trade
+tradeGeneration_ (market, broker, clientAccounts) =
+  clientOrders_
+    >=> execute_ (market, broker)
+    >=> allocate_ clientAccounts

--- a/examples/Contains.elm
+++ b/examples/Contains.elm
@@ -12,12 +12,12 @@ contains y xs =
     [] ->
       False
 
-contains' : a -> List a -> Constraint (Eq a r) Bool
-contains' y xs =
+contains_ : a -> List a -> Constraint (Eq a r) Bool
+contains_ y xs =
   ask >>= \c ->
     case xs of
       x::xss ->
-        contains' y xss <&> \b ->
+        contains_ y xss <&> \b ->
           c.eq x y || b
       [] ->
         pure False
@@ -30,26 +30,26 @@ sum ns =
     [] ->
       0
 
-sum' : List a -> Constraint (Monoid a r) a
-sum' ns =
+sum_ : List a -> Constraint (Monoid a r) a
+sum_ ns =
   ask >>= \c ->
     case ns of
       n::nss ->
-        sum' nss <&> c.concat n
+        sum_ nss <&> c.concat n
       [] ->
         pure c.identity
 
 sumIfContained : a -> List a -> Constraint (Monoid a (Eq a r)) a
 sumIfContained x xs =
-  contains' x xs >>= \b ->
+  contains_ x xs >>= \b ->
     if b then
-      sum' xs
+      sum_ xs
     else
-      sum' []
+      sum_ []
 
 total : Constraint (Monoid number {}) number
 total =
-  sum' [1,2,3]
+  sum_ [1,2,3]
 
 six : Int
 six =

--- a/src/Constraint/Eq.elm
+++ b/src/Constraint/Eq.elm
@@ -42,8 +42,8 @@ eqMaybe constraint =
     case (x, y) of
       (Nothing, Nothing) ->
         True
-      (Just x', Just y') ->
-        constraint.eq x' y'
+      (Just x_, Just y_) ->
+        constraint.eq x_ y_
       _ ->
         False
   }
@@ -56,10 +56,10 @@ eqEither aConstraint bConstraint =
   { aConstraint
   | eq = \x y ->
     case (x, y) of
-      (Err x', Err y') ->
-        aConstraint.eq x' y'
-      (Ok x', Ok y') ->
-        bConstraint.eq x' y'
+      (Err x_, Err y_) ->
+        aConstraint.eq x_ y_
+      (Ok x_, Ok y_) ->
+        bConstraint.eq x_ y_
       _ ->
         False
   }
@@ -69,8 +69,8 @@ If we have an `Eq a r`, then we can make an `Eq (List a) r`.
 -}
 eqList : Eq a r -> Eq (List a) r
 eqList constraint =
-  let equateLists list list' =
-    case (list, list') of
+  let equateLists list list_ =
+    case (list, list_) of
       ([], []) ->
         True
       (x::xs, y::ys) ->

--- a/src/Constraint/Ord.elm
+++ b/src/Constraint/Ord.elm
@@ -54,8 +54,8 @@ ordMaybe constraint =
         LT
       (Just _, Nothing) ->
         GT
-      (Just x', Just y') ->
-        constraint.compare x' y'
+      (Just x_, Just y_) ->
+        constraint.compare x_ y_
   }
 
 {-|
@@ -66,14 +66,14 @@ ordEither aConstraint bConstraint =
   { aConstraint
   | compare = \x y ->
     case (x, y) of
-      (Err x', Err y') ->
-        aConstraint.compare x' y'
+      (Err x_, Err y_) ->
+        aConstraint.compare x_ y_
       (Err _, Ok _) ->
         LT
       (Ok _, Err _) ->
         GT
-      (Ok x', Ok y') ->
-        bConstraint.compare x' y'
+      (Ok x_, Ok y_) ->
+        bConstraint.compare x_ y_
   }
 
 {-|
@@ -81,8 +81,8 @@ If we have an `Ord a r`, then we can make an `Ord (List a) r`.
 -}
 ordList : Ord a r -> Ord (List a) r
 ordList constraint =
-  let compareLists list list' =
-    case (list, list') of
+  let compareLists list list_ =
+    case (list, list_) of
       ([], []) ->
         EQ
       ([], _) ->


### PR DESCRIPTION
Greetings!

I've been thinking about type-classy things in Elm lately, came across this experiment, and found it quite fascinating. Here is a little PR to update it for Elm 0.18 ... the changes are trivial.

But, I mostly want to think aloud a bit about all of this.

I've sometimes used a type-class like mechanism in Elm ... I described the technique in a [blog post](https://www.gizra.com/content/elm-related-types/) here.

Now, the way I've done it is by doing manually something like what the compiler does automatically in some languages ... that is, requiring an extra parameter as the first parameter to a function, where the parameter supplies a record of functions or other things which are needed. So, like typeclasses, except you have to supply them manually -- the compiler doesn't keep track for you.

What you're doing here is roughly similar in purpose, but it works almost backwards. Instead of requiring an extra parameter to functions up-front, the functions accept "normal" parameters, but return a kind of hypothetical answer -- you can get the "real" answer if you take the answer and fulfill certain constraints. And, you can work "inside" the hypothetical for a while ... that is, you can build up a complex hypothetical with several kinds of constraint, and then fulfill them all in one fell swoop at the end (when you actually need to really resolve the answer).

So, programming in this style would end up feeling something like programming "inside" a monad does in Haskell ... you'd build up the nature of the needed monad for your calculation, and then fulfill it at the point where you need to extract the answer.

Without having played with this yet, I find it potentially conceptually appealing. I think it may solve a kind of problem with the approach I'd been using, which is this: how do you guarantee that a **consistent** typeclass is supplied, over time, as you call various functions that require one? This isn't a problem in language like Haskell, which guarantees that you'll get the same typeclass for the same type every time (well, unless you allow orphan instances ...). But it would be in Elm, if you're manually supplying the type class every time you call a function.

 I noticed the problem in thinking about some changes that would be desirable in `eeue56/elm-all-dict` ... I commented on it in [this PR](https://github.com/eeue56/elm-all-dict/pull/4). To summarize:

- `elm-all-dict` currently stores an ordering function in the data type itself. But this causes logical problems for functions that combine two dicts ... which ordering function should be used?

- You could imagine (in my style) supplying the ordering function for each function call. But this causes a different kind of problem ... you don't have a guarantee that each function is called with the same typeclass (since they are supplied manually).

Your approach might help here, I think, since it kind of "defers" the selection of the typeclass to the point where the value really needs to be resolved. One may, by that point, have built up quite a complicated hypothetical calculation, and one can be assured that -- at least in resolving it -- a consistent set of typeclasses will be applied.

At least, that's my intuition about what your approach would do -- I'd be curious to know whether that seems to be on the right track, and what you thought about your experiment.

The reason I'm interested is that I'm working on an idea for a better implementation of elm-all-dict ... I have some [work-in-progress](https://github.com/rgrempel/elm-all-dict/pull/1). To do that, I made a typeclass-like `Comparable` type, which is roughly similar in purpose to your `Constraint.Ord`. To solve the "enforce consistent typeclasses" problem, I played with the "module functor" pattern, where you supply the typeclass to get a [pre-applied version of all the functions](https://github.com/rgrempel/elm-all-dict/blob/be2949b16b72b1594337e3e36038f69c472a6bf5/src/AllDict.elm#L127-L173) in the module (as a record), specialized for the appropriate class. That works to a degree, though it's a bit crippled by the lack of higher-kinded polymorphism and Rank-N types ... there are some real limits to what you can express that way.

Anyway, it occurred to me that your approach might be nicer -- I plan to give that a try and see how it feels. I'm curious whether you ran into any dead ends that I should watch for!